### PR TITLE
Add default sound to iOS push payload

### DIFF
--- a/sender/provider/fcm/fcm.go
+++ b/sender/provider/fcm/fcm.go
@@ -137,6 +137,7 @@ func (f *fcmSender) buildFcmIosMessage(message domain.Message) *messaging.Multic
 			Payload: &messaging.APNSPayload{
 				Aps: &messaging.Aps{
 					MutableContent: true,
+					Sound:          "default",
 				},
 			},
 		},


### PR DESCRIPTION
## Summary

- iOS push notifications arrive silently. The APNs payload built by `buildFcmIosMessage` sets only `mutable-content: 1`, and the Firebase Admin SDK omits the `sound` key entirely when `Aps.Sound` is empty — so the delivered notification has `content.sound == nil` and iOS plays nothing.
- Nothing sets it on the client either: the iOS notification service extension mutates `body`, `userInfo` and `badge` but never `sound`, and iOS has no per-app sound default to fall back on. Android is unaffected because it receives a data-only message and builds the notification itself, where the NotificationChannel supplies the sound.
- Setting it server-side rather than in the extension is deliberate: the extension is best-effort. On decryption failure, a missing encryption key, timeout or crash, the system falls back to the original payload — so the payload has to carry the sound for those paths to make any noise.

Payload before/after, verified against the Firebase SDK marshaller:

```
before: {"mutable-content":1}
after:  {"mutable-content":1,"sound":"default"}
```

`buildFcmIosSilentMessage` is intentionally untouched — that is the `NotifyRead` background push used to dismiss delivered notifications on other devices, and it must stay content-available only.